### PR TITLE
Fix crash with MineColonies NPC requests

### DIFF
--- a/src/main/java/com/cerbon/queen_bee/item/QBArmorMaterials.java
+++ b/src/main/java/com/cerbon/queen_bee/item/QBArmorMaterials.java
@@ -51,7 +51,7 @@ public enum QBArmorMaterials implements StringRepresentable, ArmorMaterial {
     }
 
     public int getDefenseForType(ArmorItem.@NotNull Type p_266752_) {
-        return this.protectionFunctionForType.get(p_266752_);
+        return this.protectionFunctionForType.getOrDefault(p_266752_, 0);
     }
 
     public int getEnchantmentValue() {


### PR DESCRIPTION
Fixes an issue initially reported at https://github.com/ldtteam/minecolonies/issues/9599

When an NPC requests armor and goes over the Antenna headgear, the game crashes due to a `NullPointerException` occurring at the method `QBArmorMaterials.getDefenseForType(ArmorItem.Type)`. This PR modifies the method to return a default value of 0 to prevent the crash.
